### PR TITLE
fix: participant slot size for calls with up to 4 or 5 participants

### DIFF
--- a/src/components/basic/Video.tsx
+++ b/src/components/basic/Video.tsx
@@ -48,7 +48,7 @@ export const Video = forwardRef<HTMLVideoElement | null, VideoProps>(
               height: {
                 xs: "120px",
                 md: "230px",
-                xl: "350px",
+                xl: "315px",
               },
               objectFit: "scale-down",
             }}

--- a/src/components/basic/Video.tsx
+++ b/src/components/basic/Video.tsx
@@ -47,7 +47,8 @@ export const Video = forwardRef<HTMLVideoElement | null, VideoProps>(
               ...sx,
               height: {
                 xs: "120px",
-                md: "350px",
+                md: "230px",
+                xl: "350px",
               },
               objectFit: "scale-down",
             }}

--- a/src/features/p2p-call/P2PCallMain.tsx
+++ b/src/features/p2p-call/P2PCallMain.tsx
@@ -83,7 +83,10 @@ export default function P2PCallMain() {
   const getSlotStyles = useCallback((): BoxProps["sx"] => {
     return {
       flexBasis: "30%",
-      margin: 1,
+      margin: {
+        xs: 0,
+        md: 1,
+      },
       width: "100%",
     };
   }, []);

--- a/src/features/p2p-call/P2PCallMain.tsx
+++ b/src/features/p2p-call/P2PCallMain.tsx
@@ -82,7 +82,7 @@ export default function P2PCallMain() {
 
   const getSlotStyles = useCallback((): BoxProps["sx"] => {
     return {
-      flexBasis: "35%",
+      flexBasis: "30%",
       margin: 1,
       width: "100%",
     };
@@ -124,6 +124,10 @@ export default function P2PCallMain() {
           display: {
             xs: "grid",
             md: "flex",
+          },
+          flexWrap: {
+            xs: "unset",
+            md: "wrap",
           },
           gridTemplateColumns: landscape ? "repeat(5, auto)" : "auto auto",
           gap: 1,


### PR DESCRIPTION
**1366x768**

Before:

![Screenshot 2023-10-28 at 01 47 02](https://github.com/MazuhSoftwares/octo-call/assets/32344098/fd929f76-b608-4474-9296-b3ae66c6b15b)

After:

![Screenshot 2023-10-28 at 01 42 20](https://github.com/MazuhSoftwares/octo-call/assets/32344098/906a0dec-1d39-442e-9d84-be8e88f147a3)

**1920x1080**

Before:

![Screenshot 2023-10-28 at 01 49 41](https://github.com/MazuhSoftwares/octo-call/assets/32344098/0b629009-f387-4a20-985d-4736a2caa677)

After:

![Screenshot 2023-10-28 at 01 52 14](https://github.com/MazuhSoftwares/octo-call/assets/32344098/ba20068b-4c2b-4efc-ba73-6fa94d18ec79)

Mobile:

Before:

![Screenshot 2023-10-28 at 18 09 48](https://github.com/MazuhSoftwares/octo-call/assets/32344098/33565ee0-7b85-4b88-8d73-7803c0be86c6)


After:

![Screenshot 2023-10-28 at 18 06 36](https://github.com/MazuhSoftwares/octo-call/assets/32344098/f52ba85b-cdf1-4123-bd6a-6e9979439aad)


